### PR TITLE
[#2618490] Warn if theme registry rebuild is enabled.

### DIFF
--- a/dashboard_connector.info
+++ b/dashboard_connector.info
@@ -16,3 +16,4 @@ files[] = plugins/checker/RequirementsChecker.php
 files[] = plugins/checker/ViewsChecker.php
 files[] = plugins/checker/AdminViewsChecker.php
 files[] = plugins/checker/PerformanceChecker.php
+files[] = plugins/checker/ThemeChecker.php

--- a/plugins/checker/ThemeChecker.php
+++ b/plugins/checker/ThemeChecker.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @file
+ * Contains ThemeChecker
+ */
+
+/**
+ * Checks whether any views are in overridden state.
+ */
+class ThemeChecker implements CheckerInterface {
+
+  /**
+   * The current active theme.
+   */
+  private $theme = null;
+
+  /**
+   * The current active theme settings.
+   */
+  private $settings = array();
+
+  /**
+   * Constructor.
+   */
+  function __construct() {
+    $this->theme = variable_get('theme_default');
+    $this->settings = variable_get('theme_' . $this->theme . '_settings', array());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getChecks() {
+    $checks = array();
+
+    // The || should cause the more expensive base theme checking function to
+    // not run if the current theme has this setting enabled.
+    if ($this->checkTheme() || $this->checkBaseThemes()) {
+      $checks[] = array(
+        'name'        => $this->theme,
+        'description' => t('The theme registry is being rebuilt on each request.'),
+        'type'        => 'theme',
+        'alert_level' => 'warning',
+      );
+    }
+
+    return $checks;
+  }
+
+  /**
+   * Check the theme settings.
+   */
+  private function checkTheme() {
+    return !(empty($this->settings['rebuild_registry']) && empty($this->settings[$this->theme . '_rebuild_registry']));
+  }
+
+  /**
+   * Check any base theme settings.
+   */
+  private function checkBaseThemes() {
+    $themes = list_themes();
+    $bases = array_keys(drupal_find_base_themes($themes, $this->theme));
+
+    foreach ($bases as $base) {
+      if (!empty($this->settings[$base . '_rebuild_registry'])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+}

--- a/plugins/checker/ThemeChecker.php
+++ b/plugins/checker/ThemeChecker.php
@@ -21,18 +21,13 @@ class ThemeChecker implements CheckerInterface {
   private $settings = array();
 
   /**
-   * Constructor.
-   */
-  public function __construct() {
-    $this->theme = variable_get('theme_default');
-    $this->settings = variable_get('theme_' . $this->theme . '_settings', array());
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function getChecks() {
     $checks = array();
+
+    $this->theme = variable_get('theme_default');
+    $this->settings = variable_get('theme_' . $this->theme . '_settings', array());
 
     // The || should cause the more expensive base theme checking function to
     // not run if the current theme has this setting enabled.

--- a/plugins/checker/ThemeChecker.php
+++ b/plugins/checker/ThemeChecker.php
@@ -13,7 +13,7 @@ class ThemeChecker implements CheckerInterface {
   /**
    * The current active theme.
    */
-  private $theme = null;
+  private $theme = NULL;
 
   /**
    * The current active theme settings.
@@ -23,7 +23,7 @@ class ThemeChecker implements CheckerInterface {
   /**
    * Constructor.
    */
-  function __construct() {
+  public function __construct() {
     $this->theme = variable_get('theme_default');
     $this->settings = variable_get('theme_' . $this->theme . '_settings', array());
   }

--- a/plugins/checker/theme_checker.inc
+++ b/plugins/checker/theme_checker.inc
@@ -1,0 +1,5 @@
+<?php
+// @codingStandardsIgnoreFile
+$plugin = array(
+  'class' => '\ThemeChecker',
+);


### PR DESCRIPTION
Picks up the setting from the base theme (bootstrap in this case). Zen uses the same (prefixed) variable name, so it'll work on most PNX sites.

````
cafugeo@somebox:~$ ./dashboard.php snapshot -s local_dev
 Timestamp: 2015-11-19 10:10:18 
 Client ID: local_dev           
 Site ID:   local_dev           
 ================= ========================== ================================================ ============= 
  Type              Name                       Description                                      Alert Level  
 ================= ========================== ================================================ ============= 
  theme             caffeinated                The theme registry is being rebuilt on each r…   warning      
  module            admin_menu                 Up to date                                       notice       
  module            admin_views                Up to date                                       notice
  module disabled   views_ui                   views_ui module is enabled                       warning      
 ================= ========================== ================================================ =============
````